### PR TITLE
feat: Add nil pointer faking

### DIFF
--- a/faker.go
+++ b/faker.go
@@ -397,11 +397,16 @@ func FakeDataSkipFields(a interface{}, fieldsToSkip []string) error {
 	return nil
 }
 
-type generator struct {
+// Generator exposes a function to get the next faked instance in a collection
+type Generator interface {
+	Next(a interface{}) (done bool, err error)
+}
+
+type nilPointerGenerator struct {
 	index int
 }
 
-func (g *generator) Next(a interface{}) (done bool, err error) {
+func (g *nilPointerGenerator) Next(a interface{}) (done bool, err error) {
 	reflectType := reflect.TypeOf(a)
 
 	if reflectType.Kind() != reflect.Ptr {
@@ -442,8 +447,8 @@ func (g *generator) Next(a interface{}) (done bool, err error) {
 // FakeDataWithNilPointerGenerator returns a generator that can be used to create successive fakes with
 // a single pointer set to nil. This can be used to iterate through fakes with all possible pointer fields
 // set to nil, to catch nil pointer-dereference errors.
-func FakeDataWithNilPointerGenerator() *generator {
-	return &generator{
+func FakeDataWithNilPointerGenerator() Generator {
+	return &nilPointerGenerator{
 		index: 0,
 	}
 }

--- a/faker.go
+++ b/faker.go
@@ -440,8 +440,8 @@ func (g *generator) Next(a interface{}) (done bool, err error) {
 }
 
 // FakeDataWithNilPointerGenerator returns a generator that can be used to create successive fakes with
-// a single nullable field set to nil. This can be used to iterate through fakes with all possible nullable fields
-// set to nil to catch nil pointer-dereference errors.
+// a single pointer set to nil. This can be used to iterate through fakes with all possible pointer fields
+// set to nil, to catch nil pointer-dereference errors.
 func FakeDataWithNilPointerGenerator() *generator {
 	return &generator{
 		index: 0,
@@ -512,8 +512,8 @@ func RemoveProvider(tag string) error {
 	return nil
 }
 
-// seenNullableFields is used to keep track of the number of nullable fields that have been encountered
-// while recursing. A field will be set to nil if seenPointers matches nilIndex. If nilIndex is -1,
+// seenPointers is used to keep track of the number of pointers that have been encountered
+// while recursing. A pointer will be set to nil if seenPointers matches nilIndex. If nilIndex is -1,
 // no pointers will be set to nil.
 func getValue(a interface{}, seenPointers *int, nilIndex int) (reflect.Value, error) {
 	t := reflect.TypeOf(a)

--- a/faker_test.go
+++ b/faker_test.go
@@ -1998,6 +1998,55 @@ func TestFakeData3(t *testing.T) {
 	})
 }
 
+func TestFakeDataWithNilPointerGenerator(t *testing.T) {
+	t.Run("test fake data with nil pointer generator", func(t *testing.T) {
+		type s struct {
+			A *int
+			B *struct {
+				C *int
+			}
+		}
+		gen := FakeDataWithNilPointerGenerator()
+
+		f := new(s)
+		done, err := gen.Next(f)
+		if done {
+			t.Error("Next returned done = true after one call, want false")
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if f.A != nil {
+			t.Errorf("got f.A = %v, but want nil", f.A)
+		}
+		if f.B == nil {
+			t.Error("got f.B = nil, but want non-nil after first step")
+		}
+
+		done, err = gen.Next(f)
+		if done {
+			t.Error("Next returned done = true after two calls, want false")
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if f.B != nil {
+			t.Errorf("got f.B = %v, but want nil", f.B)
+		}
+
+		done, err = gen.Next(f)
+		if !done {
+			t.Error("Next returned done = false after three calls, want true")
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if f.B.C != nil {
+			t.Errorf("got f.B.C = %v, but want nil", f.B.C)
+		}
+	})
+}
+
 // getStringLen for language independent string length
 func utfLen(value string) int {
 	var r int


### PR DESCRIPTION
Adds `FakeDataWithNilPointerGenerator`, a function that returns a generator. On successive calls, the generator returns a filled out interface with exactly one pointer field set to nil. This can be used in tests to detect nil pointer dereference errors.